### PR TITLE
Merge wordbound blanks and add to all LUs in output

### DIFF
--- a/src/lsx_processor.cc
+++ b/src/lsx_processor.cc
@@ -282,7 +282,8 @@ LSXProcessor::processWord(FILE* input, FILE* output)
       pos += 3;
     }
   }
-  // TODO: figure out where bound blanks actually go
+  
+  wstring wblank;
   size_t i = 0;
   for(; i < out_lus.size(); i++)
   {
@@ -290,25 +291,35 @@ LSXProcessor::processWord(FILE* input, FILE* output)
     {
       fputws_unlocked(blank_queue[i].c_str(), output);
       
-      for(size_t j = 0; j < out_lus.size(); j++)
+      if(wblank.empty())
       {
-        if(bound_blank_queue[j].size() > 0)
+        for(size_t j = 0; j < out_lus.size(); j++)
         {
-          if(j == 0)
+          if(bound_blank_queue[j].size() > 0)
           {
-            fputws_unlocked(L"[[", output);
-          }
-          else if(j > 0)
-          {
-            fputws_unlocked(L"; ", output);
-          }
-          fputws_unlocked(bound_blank_queue[j].c_str(), output);
-          
-          if(j == out_lus.size() - 1)
-          {
-            fputws_unlocked(L"]]", output);
+            if(j == 0)
+            {
+              wblank += L"[[";
+            }
+            else if(j > 0)
+            {
+              wblank += L"; ";
+            }
+            
+            wblank += bound_blank_queue[j].c_str();
+            
+            if(j == out_lus.size() - 1)
+            {
+              wblank += L"]]";
+            }
           }
         }
+        
+        fputws_unlocked(wblank.c_str(), output);
+      }
+      else
+      {
+        fputws_unlocked(wblank.c_str(), output);
       }
       
     }

--- a/src/lsx_processor.cc
+++ b/src/lsx_processor.cc
@@ -289,12 +289,28 @@ LSXProcessor::processWord(FILE* input, FILE* output)
     if(i < last_final)
     {
       fputws_unlocked(blank_queue[i].c_str(), output);
-      if(bound_blank_queue[i].size() > 0)
+      
+      for(size_t j = 0; j < out_lus.size(); j++)
       {
-        fputws_unlocked(L"[[", output);
-        fputws_unlocked(bound_blank_queue[i].c_str(), output);
-        fputws_unlocked(L"]]", output);
+        if(bound_blank_queue[j].size() > 0)
+        {
+          if(j == 0)
+          {
+            fputws_unlocked(L"[[", output);
+          }
+          else if(j > 0)
+          {
+            fputws_unlocked(L"; ", output);
+          }
+          fputws_unlocked(bound_blank_queue[j].c_str(), output);
+          
+          if(j == out_lus.size() - 1)
+          {
+            fputws_unlocked(L"]]", output);
+          }
+        }
       }
+      
     }
     else
     {


### PR DESCRIPTION
Since there is no aligning in -separable rules, this seems to be the safest solution of distributing information on output LUs.

For multiwords (many to one), this will work fine, and for one to many as well. For many to many, this will duplicate some information. Still thinking of better ways to deal with this.

Example:
Input:
```
^the<det><def><sp>$ [[t:i:123456]]^Aragonese<n><sg>$ [[t:b:basfs]]^take<vblex><past>$ [[t:s:123545]]^Ramiro<np><ant><m><sg>$ [[t:x:abc123]]^out of<pr>$ [[t:y:vdfdrf]]^a<det><ind><sg>$
^monastery<n><sg>$ ^and<cnjcoo>$ ^make<vblex><pp>$ ^prpers<prn><obj><p3><m><sg>$ ^king<n><sg>$^.<sent>$

[[t:b:basfs]]^take<vblex><past>$ [[t:s:123545]]^Ramiro<np><ant><m><sg>$ [[t:x:abc123]]^out<adv>$ ^of<pr>$ [[t:y:vdfdrf]]^a<det><ind><sg>$
```

Output:
```
^the<det><def><sp>$ [[t:i:123456]]^Aragonese<n><sg>$ [[t:b:basfs; t:s:123545; t:x:abc123]]^take# out<vblex><sep><past>$ [[t:b:basfs; t:s:123545; t:x:abc123]]^Ramiro<np><ant><m><sg>$ [[t:b:basfs; t:s:123545; t:x:abc123]]^of<pr>$ [[t:y:vdfdrf]]^a<det><ind><sg>$
^monastery<n><sg>$ ^and<cnjcoo>$ ^make<vblex><pp>$ ^prpers<prn><obj><p3><m><sg>$ ^king<n><sg>$^.<sent>$

[[t:b:basfs; t:s:123545; t:x:abc123]]^take# out<vblex><sep><past>$ [[t:b:basfs; t:s:123545; t:x:abc123]]^Ramiro<np><ant><m><sg>$ [[t:b:basfs; t:s:123545; t:x:abc123]]^<adv>$ ^of<pr>$ [[t:y:vdfdrf]]^a<det><ind><sg>$
```