### PR TITLE
ignore output <t/>

### DIFF
--- a/src/lsx_compiler.cc
+++ b/src/lsx_compiler.cc
@@ -220,6 +220,7 @@ Compiler::matchTransduction(list<int> const &pi, list<int> const &pd, int estado
               // rl compilation of a badly written rule
               // having an epsilon with wildcard output will produce
               // garbage output -- see https://github.com/apertium/apertium-separable/issues/8
+              wcerr << L"Warning: Cannot insert <t/> from empty input. Ignoring. (You probably want to specify exact tags when deleting a word.)" << endl;
               continue;
             }
 

--- a/src/lsx_compiler.cc
+++ b/src/lsx_compiler.cc
@@ -213,13 +213,21 @@ Compiler::matchTransduction(list<int> const &pi, list<int> const &pd, int estado
                 dcha++;
             }
 
+            if(etiqueta == alphabet(0, alphabet(L"<ANY_TAG>")) ||
+               etiqueta == alphabet(0, alphabet(L"<ANY_CHAR>"))
+              )
+            {
+              // rl compilation of a badly written rule
+              // having an epsilon with wildcard output will produce
+              // garbage output -- see https://github.com/apertium/apertium-separable/issues/8
+              continue;
+            }
+
             int nuevo_estado = t.insertSingleTransduction(etiqueta, estado);
             if(etiqueta == alphabet(alphabet(L"<ANY_TAG>"),alphabet(L"<ANY_TAG>"))
                || etiqueta == alphabet(alphabet(L"<ANY_CHAR>"),alphabet(L"<ANY_CHAR>"))
                || etiqueta == alphabet(alphabet(L"<ANY_TAG>"), 0)
                || etiqueta == alphabet(alphabet(L"<ANY_CHAR>"), 0)
-               || etiqueta == alphabet(0, alphabet(L"<ANY_TAG>"))
-               || etiqueta == alphabet(0, alphabet(L"<ANY_CHAR>"))
               )
             {
                 t.linkStates(nuevo_estado, estado, 0);


### PR DESCRIPTION
See #7 and #8.

When a rule contains something like
```xml
<p>
  <l>out<t/><j/></l>
  <r></r>
</p>
```
it works just find in the `lr` direction (deleting `^out<adv>$`), but in the `rl` direction there's a loop with epsilon input and `<ANY_TAG>` output which very quickly fills available memory when lttoolbox tries to take the epsilon closure of the current state.

This PR make it so that in `rl` compilation the `<t/>` is simply ignored and this segment outputs `^out$` with no tags.

In a moment I'll add a warning message to the compiler.