### PR TITLE
Fix #37 – ANY_ should self-loop from new state, not from previous state

### DIFF
--- a/src/lsx_compiler.cc
+++ b/src/lsx_compiler.cc
@@ -231,7 +231,7 @@ Compiler::matchTransduction(list<int> const &pi, list<int> const &pd, int estado
                || etiqueta == alphabet(alphabet(L"<ANY_CHAR>"), 0)
               )
             {
-                t.linkStates(nuevo_estado, estado, 0);
+                t.linkStates(nuevo_estado, nuevo_estado, etiqueta);
             }
             estado = nuevo_estado;
         }


### PR DESCRIPTION
since the previous may be initial, ie. shared with leading completely unrelated entries.

Passes make check, I'm doing a corpus run with nno-nob as well (only progressions on the first 42000 lines); but are there other language pairs with more developed lsx files I should regression check?